### PR TITLE
Add a delay option for untriggering the sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Additionally, you can set the following settings globally, outside of the `senso
 Variable | Description
 -------- | -----------
 `logSeenPlayersAndUsers` | (Optional - default: false) Setting this to true will log every player device name and username that the plugin sees starting a playback from the webhook, potentially useful for figuring out device names.
+`delayOff` | (Optional - default: 0) Setting this to a value above 0 will delay the occupancy sensor being untriggered when playback is stopped. This timeout is measured in milliseconds.
 `debug` | (Optional - default: false) Setting this to true will log every webhook and how it is handled by the plugin's logic. You should probably leave this false, but you might find it useful for looking at the entire contents of a webhook payload.
 
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ Variable | Description
 `genres` | (Optional) This is an array of genre strings. If set, movie playbacks will only trigger the sensor if the movie's genre matches one or more of the genres in this array.
 `ignorePauseResume` | (Optional - default: false) If set to true the sensor will remain "triggered" while playback is paused. By default paused players will untrigger the sensor.
 `customFilters` | (Optional / Advanced) Custom filters allow you to filter for specific properties on the JSON events that the above use cases don't cover. For example you could make a sensor only triggered by playing a specific TV Show or movie. See [Plex's article on Webhooks](https://support.plex.tv/articles/115002267687-webhooks/) for more details of what is passed in webhook events.
+`delayOff` | (Optional - default: 0) Setting this to a value above 0 will delay the occupancy sensor being untriggered when playback is stopped. This timeout is measured in milliseconds.
 
 Additionally, you can set the following settings globally, outside of the `sensors` object:
 
 Variable | Description
 -------- | -----------
 `logSeenPlayersAndUsers` | (Optional - default: false) Setting this to true will log every player device name and username that the plugin sees starting a playback from the webhook, potentially useful for figuring out device names.
-`delayOff` | (Optional - default: 0) Setting this to a value above 0 will delay the occupancy sensor being untriggered when playback is stopped. This timeout is measured in milliseconds.
+
 `debug` | (Optional - default: false) Setting this to true will log every webhook and how it is handled by the plugin's logic. You should probably leave this false, but you might find it useful for looking at the entire contents of a webhook payload.
 
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -48,7 +48,8 @@
                 }
             ],
             "debug": true,
-            "logSeenPlayersAndUsers": true
+            "logSeenPlayersAndUsers": true,
+            "delayOff": 3000000
         }
     ],
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -19,13 +19,14 @@
                   "name": "Movie Playing",
                   "types": ["movie"],
                   "players": ["Living Room"],
-                  "users": ["MyUserName"]
+                  "users": ["MyUserName"],
+                  "delayOff": 1000000
                 },
                 {
                   "name": "TV Playing",
                   "types": ["episode"],
                   "players": ["Living Room"],
-                  "users": ["MyUserName"]
+                  "delayOff": 3000000
                 },
                 {
                     "name": "Horror Movie",
@@ -48,8 +49,7 @@
                 }
             ],
             "debug": true,
-            "logSeenPlayersAndUsers": true,
-            "delayOff": 3000000
+            "logSeenPlayersAndUsers": true
         }
     ],
 

--- a/index.js
+++ b/index.js
@@ -252,11 +252,19 @@ Plex.prototype.processEvent = function(self, event, sensor) {
         sensor.activePlayers.delete(event.Player.uuid);
         if (sensor.activePlayers.size == 0)
         {
-            self.debugLog("Event scheduled sensor off: "+sensor.name+" after "+this.delayOff+"ms");
-            this.timeout = setTimeout(function() {
-                self.debugLog("Event triggered sensor off: "+sensor.name);
+            if (this.delayOff > 0)
+            {
+                self.debugLog("Event scheduled sensor off: "+sensor.name+" after "+this.delayOff+"ms");
+                this.timeout = setTimeout(function() {
+                    self.debugLog("Event triggered sensor off: "+sensor.name);
+                    sensor.service.getCharacteristic(Characteristic.OccupancyDetected).updateValue(false);
+                }.bind(this), this.delayOff);
+            }
+            else
+            {
+                self.debugLog("Event triggered sensor off without delay: "+sensor.name);
                 sensor.service.getCharacteristic(Characteristic.OccupancyDetected).updateValue(false);
-            }.bind(this), this.delayOff);
+            }
         }
     }
     else

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function Plex(log, config, api) {
     this.port = config["port"] || '22987';
     this.logSeenPlayersAndUsers = config["logSeenPlayersAndUsers"] || false;
     this.delayOff = config["delayOff"] || 0;
-    this.timer;
+    this.timeout;
     debug = config["debug"] || false;
     var self = this;
         


### PR DESCRIPTION
This PR adds a `delayOff` option, set to 0 by default, to delay the occupancy sensor being 'untriggered' when playback is stopped. The timeout is cancelled if another play event occurs before the untriggering occurs.